### PR TITLE
chore: use dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "chore"
+    ignore:
+      # GitHub always delivers the latest versions for each major
+      # release tag, so handle updates manually
+      - dependency-name: "actions/*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Chicago"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Use dependabot to manage the dependencies defined in go.mod and
GitHub Actions workflows, so that we can proactively update versions.

Outdated versions of third-party dependencies frequently have known
security vulnerabilities with CVEs.