### PR TITLE
chore: updates to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,51 @@
 name: ci
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
       - name: make fmt
         uses: ./ci/image
         with:
           args: make fmt
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
       - name: make lint
         uses: ./ci/image
         with:
           args: make lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
       - name: make test
         uses: ./ci/image
         with:
           args: make test
         env:
           COVERALLS_TOKEN: ${{ secrets.github_token }}
+
       - name: Upload coverage.html
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: coverage
           path: ci/out/coverage.html


### PR DESCRIPTION
* Pin runners to ubuntu-20.04 so that we can control upgrades
* Update GitHub official actions to latest major versions (v2)
* Build on push events on default branch, as well as pull request
  events against the default branch (fixes: #98)