### PR TITLE
fix: Stdlog writer should output with the logger level

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -111,7 +111,7 @@ func ExampleWith() {
 
 func ExampleStdlib() {
 	ctx := slog.With(context.Background(), slog.F("field", 1))
-	l := slog.Stdlib(ctx, slog.Make(sloghuman.Sink(os.Stdout)))
+	l := slog.Stdlib(ctx, slog.Make(sloghuman.Sink(os.Stdout)), slog.LevelInfo)
 
 	l.Print("msg")
 

--- a/s.go
+++ b/s.go
@@ -39,7 +39,7 @@ func (w stdlogWriter) Write(p []byte) (n int, err error) {
 	// we do not want.
 	msg = strings.TrimSuffix(msg, "\n")
 
-	w.l.Info(w.ctx, msg)
+	w.l.log(w.ctx, w.l.level, msg, Map{})
 
 	return len(p), nil
 }

--- a/s.go
+++ b/s.go
@@ -8,15 +8,15 @@ import (
 
 // Stdlib creates a standard library logger from the given logger.
 //
-// All logs will be logged at the Info level and the given ctx
-// will be passed to the logger's Info method, thereby logging
-// all fields and tracing info in the context.
+// All logs will be logged at the level set by the logger and the
+// given ctx will be passed to the logger's Log method, thereby
+// logging all fields and tracing info in the context.
 //
 // You can redirect the stdlib default logger with log.SetOutput
 // to the Writer on the logger returned by this function.
 // See the example.
 func Stdlib(ctx context.Context, l Logger) *log.Logger {
-	l.skip += 3
+	l.skip += 2
 
 	l = l.Named("stdlib")
 

--- a/s.go
+++ b/s.go
@@ -15,22 +15,24 @@ import (
 // You can redirect the stdlib default logger with log.SetOutput
 // to the Writer on the logger returned by this function.
 // See the example.
-func Stdlib(ctx context.Context, l Logger) *log.Logger {
+func Stdlib(ctx context.Context, l Logger, level Level) *log.Logger {
 	l.skip += 2
 
 	l = l.Named("stdlib")
 
 	w := &stdlogWriter{
-		ctx: ctx,
-		l:   l,
+		ctx:   ctx,
+		l:     l,
+		level: level,
 	}
 
 	return log.New(w, "", 0)
 }
 
 type stdlogWriter struct {
-	ctx context.Context
-	l   Logger
+	ctx   context.Context
+	l     Logger
+	level Level
 }
 
 func (w stdlogWriter) Write(p []byte) (n int, err error) {
@@ -39,7 +41,7 @@ func (w stdlogWriter) Write(p []byte) (n int, err error) {
 	// we do not want.
 	msg = strings.TrimSuffix(msg, "\n")
 
-	w.l.log(w.ctx, w.l.level, msg, Map{})
+	w.l.log(w.ctx, w.level, msg, Map{})
 
 	return len(p), nil
 }

--- a/s_test.go
+++ b/s_test.go
@@ -17,7 +17,7 @@ func TestStdlib(t *testing.T) {
 	l := slog.Make(sloghuman.Sink(b)).With(
 		slog.F("hi", "we"),
 	)
-	stdlibLog := slog.Stdlib(bg, l)
+	stdlibLog := slog.Stdlib(bg, l, slog.LevelInfo)
 	stdlibLog.Println("stdlib")
 
 	et, rest, err := entryhuman.StripTimestamp(b.String())

--- a/sloggers/slogtest/t.go
+++ b/sloggers/slogtest/t.go
@@ -19,7 +19,7 @@ import (
 // Ensure all stdlib logs go through slog.
 func init() {
 	l := slog.Make(sloghuman.Sink(os.Stderr))
-	log.SetOutput(slog.Stdlib(context.Background(), l).Writer())
+	log.SetOutput(slog.Stdlib(context.Background(), l, slog.LevelInfo).Writer())
 }
 
 // Options represents the options for the logger returned


### PR DESCRIPTION
All output was appearing as `Info`, even though that didn't make sense.