### PR TITLE
fix: ensure (Logger).exit is non-nil before calling

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -114,6 +114,11 @@ func (l Logger) Critical(ctx context.Context, msg string, fields ...Field) {
 func (l Logger) Fatal(ctx context.Context, msg string, fields ...Field) {
 	l.log(ctx, LevelFatal, msg, fields)
 	l.Sync()
+
+	if l.exit == nil {
+		l.exit = os.Exit
+	}
+
 	l.exit(1)
 }
 

--- a/slog.go
+++ b/slog.go
@@ -118,7 +118,7 @@ func (l Logger) Fatal(ctx context.Context, msg string, fields ...Field) {
 	l.Sync()
 
 	if l.exit == nil {
-		l.exit = os.Exit
+		l.exit = defaultExitFn
 	}
 
 	l.exit(1)

--- a/slog.go
+++ b/slog.go
@@ -21,6 +21,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
+var defaultExitFn = os.Exit
+
 // Sink is the destination of a Logger.
 //
 // All sinks must be safe for concurrent use.

--- a/slog_exit_test.go
+++ b/slog_exit_test.go
@@ -1,0 +1,32 @@
+package slog
+
+import (
+	"context"
+	"testing"
+
+	"cdr.dev/slog/internal/assert"
+)
+
+func TestLogger(t *testing.T) {
+	// This can't be parallel since it modifies a global variable.
+	t.Run("defaultExitFn", func(t *testing.T) {
+		var (
+			ctx                 = context.Background()
+			log                 Logger
+			defaultExitFnCalled bool
+		)
+
+		defaultExitFn = func(_ int) {
+			defaultExitFnCalled = true
+		}
+
+		log.Debug(ctx, "hi")
+		log.Info(ctx, "hi")
+		log.Warn(ctx, "hi")
+		log.Error(ctx, "hi")
+		log.Critical(ctx, "hi")
+		log.Fatal(ctx, "hi")
+
+		assert.True(t, "default exit fn used", defaultExitFnCalled)
+	})
+}

--- a/slog_exit_test.go
+++ b/slog_exit_test.go
@@ -7,7 +7,7 @@ import (
 	"cdr.dev/slog/internal/assert"
 )
 
-func TestLogger(t *testing.T) {
+func TestExit(t *testing.T) {
 	// This can't be parallel since it modifies a global variable.
 	t.Run("defaultExitFn", func(t *testing.T) {
 		var (

--- a/slog_exit_test.go
+++ b/slog_exit_test.go
@@ -16,6 +16,9 @@ func TestExit(t *testing.T) {
 			defaultExitFnCalled bool
 		)
 
+		prevExitFn := defaultExitFn
+		t.Cleanup(func() { defaultExitFn = prevExitFn })
+
 		defaultExitFn = func(_ int) {
 			defaultExitFnCalled = true
 		}


### PR DESCRIPTION
On an empty logger (which we use), it's possible for (Logger).Fatal to
panic when attempting to call exit. This ensures that `l.exit` isn't nil
before calling it.
